### PR TITLE
Don't try to hide if `el` is missing.

### DIFF
--- a/src/js/biu.js
+++ b/src/js/biu.js
@@ -76,6 +76,8 @@
     }
 
     hide() {
+      if (!this.el) return
+        
       if (this.options.pop) {
         this.el.style.transform = 'translateX(-50%) translateY(-110%)'
       } else {


### PR DESCRIPTION
Fixes an **Uncaught TypeError: Cannot read property 'style' of null** exception when an alert is manually closed prior to setTimeout being called. Maybe you'd prefer to fix it another way, but to reproduce just open the console, trigger an alert and click `×` within the default 3 seconds.
